### PR TITLE
Curl 7.50+, SSL & HTTP2 support

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -21,7 +21,7 @@ let package = Package(
 	providers: [
 		.Brew("curl --with-openssl --with-nghttp2"),
 		.Apt("libcurl4-openssl-dev")
-	]
+	],
 	pkgConfig: "libcurl"
 
 )

--- a/Package.swift
+++ b/Package.swift
@@ -19,7 +19,9 @@ import PackageDescription
 let package = Package(
 	name: "CCurl",
 	providers: [
-		.Brew("curl"), 
+		.Brew("curl --with-openssl --with-nghttp2"),
 		.Apt("libcurl4-openssl-dev")
 	]
+	pkgConfig: "libcurl"
+
 )

--- a/Package.swift
+++ b/Package.swift
@@ -18,10 +18,9 @@ import PackageDescription
 
 let package = Package(
 	name: "CCurl",
+	pkgConfig: "libcurl",
 	providers: [
 		.Brew("curl --with-openssl --with-nghttp2"),
 		.Apt("libcurl4-openssl-dev")
-	],
-	pkgConfig: "libcurl"
-
+	]
 )


### PR DESCRIPTION
I managed to switch the default `curlib` that is shipped with macOS, with version 7.50 installed via `brew`.

It now allows you to:
- use HTTP2 protocol
- use SSL protocol

This allowed me to publish [tori-APNS](https://github.com/boostcode/tori-APNS) a lib that allow you to send push notification via server too now.
