### PR TITLE
Add header callback helper function

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -66,6 +66,18 @@ static inline CURLcode curlHelperSetOptWriteFunc(CURL *curl, void *userData, siz
     return rc;
 }
 
+static inline CURLcode curlHelperSetOptHeaderFunc(CURL *curl, void *userData, size_t (*header_cb) (char *buffer, size_t size, size_t nmemb, void *userdata)) {
+    
+    CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADER, 0);
+    if (rc == CURLE_OK) {
+        rc = curl_easy_setopt(curl, CURLOPT_HEADERDATA, userData);
+        if (rc == CURLE_OK) {
+            rc = curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_cb);
+        }
+    }
+    return rc;
+}
+
 static inline CURLcode curlHelperGetInfoCString(CURL *curl, CURLINFO info, char **data) {
     return curl_easy_getinfo(curl, info, data);
 }


### PR DESCRIPTION
Add helper function to provide callback and data pointer for writing received headers. Also sets CURLOPT_HEADER option to not include received headers in body output.