### PR TITLE
Updated to separately handle header callbacks

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -55,8 +55,8 @@ static inline CURLcode curlHelperSetOptReadFunc(CURL *curl, void *userData, size
 }
 
 static inline CURLcode curlHelperSetOptWriteFunc(CURL *curl, void *userData, size_t (*write_cb) (char *ptr, size_t size, size_t nmemb, void *userdata)) {
-    
-    CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADER, 1);
+
+    CURLcode rc;
     if  (rc == CURLE_OK)  {
         rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, userData);
         if  (rc == CURLE_OK) {
@@ -67,8 +67,8 @@ static inline CURLcode curlHelperSetOptWriteFunc(CURL *curl, void *userData, siz
 }
 
 static inline CURLcode curlHelperSetOptHeaderFunc(CURL *curl, void *userData, size_t (*header_cb) (char *buffer, size_t size, size_t nmemb, void *userdata)) {
-    
-    CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADER, 0);
+
+    CURLcode rc;
     if (rc == CURLE_OK) {
         rc = curl_easy_setopt(curl, CURLOPT_HEADERDATA, userData);
         if (rc == CURLE_OK) {


### PR DESCRIPTION
In preparation for HTTP/2 support in Kitura we've created a test case that uses the ClientRequest to communicate with a server that supports HTTP/2.
Before these changes the communication has been done over HTTP/1.1 and we had to update the ClientRequest to be able to request over HTTP/2 and parse an upgrade response correctly.

We added callback option to handle header separately as before this change they were handle together with the body.