### PR TITLE
IBM-Swift/Kitura-CouchDB#58 Remove check on uninitialized variable

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -56,24 +56,18 @@ static inline CURLcode curlHelperSetOptReadFunc(CURL *curl, void *userData, size
 
 static inline CURLcode curlHelperSetOptWriteFunc(CURL *curl, void *userData, size_t (*write_cb) (char *ptr, size_t size, size_t nmemb, void *userdata)) {
 
-    CURLcode rc;
-    if  (rc == CURLE_OK)  {
-        rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, userData);
-        if  (rc == CURLE_OK) {
-            rc = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
-        }
+    CURLcode rc = curl_easy_setopt(curl, CURLOPT_WRITEDATA, userData);
+    if  (rc == CURLE_OK) {
+        rc = curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_cb);
     }
     return rc;
 }
 
 static inline CURLcode curlHelperSetOptHeaderFunc(CURL *curl, void *userData, size_t (*header_cb) (char *buffer, size_t size, size_t nmemb, void *userdata)) {
 
-    CURLcode rc;
+    CURLcode rc = curl_easy_setopt(curl, CURLOPT_HEADERDATA, userData);
     if (rc == CURLE_OK) {
-        rc = curl_easy_setopt(curl, CURLOPT_HEADERDATA, userData);
-        if (rc == CURLE_OK) {
-            rc = curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_cb);
-        }
+        rc = curl_easy_setopt(curl, CURLOPT_HEADERFUNCTION, header_cb);
     }
     return rc;
 }


### PR DESCRIPTION
The change in #11 removed the calls to set CURLOPT_HEADER, but left in the subsequent check `if (rc == CURLE_OK)` on the uninitialized `CURLcode rc;` variable, which meant the subsequent calls were never invoked.

This is breaking several dependent repos (See https://github.com/IBM-Swift/Kitura-CouchDB/issues/58). Please tag a patch with this fix if it looks ok.