### PR TITLE
Allow curl_multi_setopt in Swift

### DIFF
--- a/shim.h
+++ b/shim.h
@@ -81,7 +81,7 @@ static inline CURLcode curlHelperGetInfoLong(CURL *curl, CURLINFO info, long *da
     return curl_easy_getinfo(curl, info, data);
 }
 
-static inline CURLcode curlHelperGetInfoLong(CURLM *curlMulti, CURLMoption option, long data) {
+static inline CURLcode curlHelperSetMultiOpt(CURLM *curlMulti, CURLMoption option, long data) {
     return curl_multi_setopt(curlMulti, option, data);
 }
 

--- a/shim.h
+++ b/shim.h
@@ -18,6 +18,8 @@
 #define CurlHelpers_h
 
 #import <curl/curl.h>
+#import <curl/multi.h>
+
 
 #define CURL_TRUE  1
 #define CURL_FALSE 0

--- a/shim.h
+++ b/shim.h
@@ -83,7 +83,7 @@ static inline CURLcode curlHelperGetInfoLong(CURL *curl, CURLINFO info, long *da
     return curl_easy_getinfo(curl, info, data);
 }
 
-static inline CURLcode curlHelperSetMultiOpt(CURLM *curlMulti, CURLMoption option, long data) {
+static inline CURMLcode curlHelperSetMultiOpt(CURLM *curlMulti, CURLMoption option, long data) {
     return curl_multi_setopt(curlMulti, option, data);
 }
 

--- a/shim.h
+++ b/shim.h
@@ -81,5 +81,9 @@ static inline CURLcode curlHelperGetInfoLong(CURL *curl, CURLINFO info, long *da
     return curl_easy_getinfo(curl, info, data);
 }
 
+static inline CURLcode curlHelperGetInfoLong(CURLM *curlMulti, CURLMoption option, long data) {
+    return curl_multi_setopt(curlMulti, option, data);
+}
+
 
 #endif /* CurlHelpers_h */


### PR DESCRIPTION
Allow to set options for `curl_multi_…` APIs by exposing this to Swift. 

Used here https://github.com/matthijs2704/vapor-apns/pull/64